### PR TITLE
Added Utils Back 🔴 

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -81,4 +81,3 @@ src/
 
 # Test and Test Utils Files
 build/*/test/
-build/utils/

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
 				"@babel/core": "7.16.12",
 				"@babel/preset-env": "7.16.11",
 				"@babel/preset-react": "7.16.7",
-				"@wordpress/scripts": "20.0.1",
+				"@wordpress/scripts": "20.0.2",
 				"cross-env": "7.0.3",
 				"husky": "7.0.4",
 				"lint-staged": "12.3.3",
@@ -4309,9 +4309,9 @@
 			}
 		},
 		"node_modules/@wordpress/scripts": {
-			"version": "20.0.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-20.0.1.tgz",
-			"integrity": "sha512-/0xkFZ3mLp7xth/GfN1bGEJiNx/gehnswelCz0+ZY9Dr/DpuWyvUhO0Sf81cZ+AMCiSbxVTVFq80i6AFb5epTA==",
+			"version": "20.0.2",
+			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-20.0.2.tgz",
+			"integrity": "sha512-6BHOAUmZ0XyjhayD5gKUuXsEpOEI8oZhcTJ85GTbib5TGBXd8VxTuh8b53fOOppbqh7YlWSSSsuMX3HaAfUYeg==",
 			"dev": true,
 			"dependencies": {
 				"@babel/core": "^7.16.0",
@@ -22442,9 +22442,9 @@
 			"dev": true
 		},
 		"@wordpress/scripts": {
-			"version": "20.0.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-20.0.1.tgz",
-			"integrity": "sha512-/0xkFZ3mLp7xth/GfN1bGEJiNx/gehnswelCz0+ZY9Dr/DpuWyvUhO0Sf81cZ+AMCiSbxVTVFq80i6AFb5epTA==",
+			"version": "20.0.2",
+			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-20.0.2.tgz",
+			"integrity": "sha512-6BHOAUmZ0XyjhayD5gKUuXsEpOEI8oZhcTJ85GTbib5TGBXd8VxTuh8b53fOOppbqh7YlWSSSsuMX3HaAfUYeg==",
 			"dev": true,
 			"requires": {
 				"@babel/core": "^7.16.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@sixa/icon-library",
-	"version": "1.3.0",
+	"version": "1.3.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@sixa/icon-library",
-			"version": "1.3.0",
+			"version": "1.3.1",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"lodash": "4.17.21"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sixa/icon-library",
-	"version": "1.3.0",
+	"version": "1.3.1",
 	"description": "Icons library.",
 	"keywords": [
 		"sixa",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
 		"@babel/core": "7.16.12",
 		"@babel/preset-env": "7.16.11",
 		"@babel/preset-react": "7.16.7",
-		"@wordpress/scripts": "20.0.1",
+		"@wordpress/scripts": "20.0.2",
 		"cross-env": "7.0.3",
 		"husky": "7.0.4",
 		"lint-staged": "12.3.3",


### PR DESCRIPTION
In #43 we accidentally added `build/utils` in `.npmignore`. Due to this, modules using this package cannot be built using `v1.3.0`. This PR adds the directory back to the published package.